### PR TITLE
Comparing dispatch_get_current_queue() with dispatch_get_main_queue()…

### DIFF
--- a/PAMainThreadNotificationCenter.m
+++ b/PAMainThreadNotificationCenter.m
@@ -53,9 +53,7 @@ static PAMainThreadNotificationCenter *_instance=nil;
 
 - (void) forwardInvocation:(NSInvocation *)anInvocation
 {
-    dispatch_queue_t que = dispatch_get_current_queue();
-    
-    if (que == dispatch_get_main_queue()) {
+    if ([NSThread isMainThread]) {
         [anInvocation invokeWithTarget:_defaultCenter];
     }
     else


### PR DESCRIPTION
… is not only deprecated since iOS6, but unreliable according to queue.h

When dispatch_get_current_queue() is called on the main thread, it may or may not return the same value as dispatch_get_main_queue(). Comparing the two is not a valid way to test whether code is executing on the main thread.
